### PR TITLE
Fix server doesn't response where error handler have an error

### DIFF
--- a/example-application/error-handling.js
+++ b/example-application/error-handling.js
@@ -5,7 +5,7 @@ const logger = require('./libraries/logger');
 const errorHandler = {
   handleError: async (errorToHandle) => {
     try {
-      logger.error(`Error occured ${errorToHandle}`);
+      logger.error(`Error occurred ${errorToHandle}`);
       metricsExporter.fireMetric('error', {
         errorName: errorToHandle.name || 'generic-error',
       });
@@ -19,7 +19,9 @@ const errorHandler = {
 
       // A common best practice is to crash when an unknown error (non-trusted) is being thrown
       decideWhetherToCrash(errorToHandle);
-    } catch (e) {}
+    } catch (e) {
+      logger.error(`handleError threw an error ${e}`);
+    }
   },
 };
 

--- a/example-application/error-handling.js
+++ b/example-application/error-handling.js
@@ -4,20 +4,22 @@ const logger = require('./libraries/logger');
 // This file simulates real-world error handler that makes this component observable
 const errorHandler = {
   handleError: async (errorToHandle) => {
-    logger.error(`Error occured ${errorToHandle}`);
-    metricsExporter.fireMetric('error', {
-      errorName: errorToHandle.name || 'generic-error',
-    });
-    // This is used to simulate sending email to admin when an error occurs
-    // In real world - The right flow is sending alerts from the monitoring system
-    await mailer.send(
-      'Error occured',
-      `Error is ${errorToHandle}`,
-      'admin@our-domain.io'
-    );
+    try {
+      logger.error(`Error occured ${errorToHandle}`);
+      metricsExporter.fireMetric('error', {
+        errorName: errorToHandle.name || 'generic-error',
+      });
+      // This is used to simulate sending email to admin when an error occurs
+      // In real world - The right flow is sending alerts from the monitoring system
+      await mailer.send(
+        'Error occured',
+        `Error is ${errorToHandle}`,
+        'admin@our-domain.io'
+      );
 
-    // A common best practice is to crash when an unknown error (non-trusted) is being thrown
-    decideWhetherToCrash(errorToHandle);
+      // A common best practice is to crash when an unknown error (non-trusted) is being thrown
+      decideWhetherToCrash(errorToHandle);
+    } catch (e) {}
   },
 };
 

--- a/example-application/error-handling.js
+++ b/example-application/error-handling.js
@@ -20,6 +20,7 @@ const errorHandler = {
       // A common best practice is to crash when an unknown error (non-trusted) is being thrown
       decideWhetherToCrash(errorToHandle);
     } catch (e) {
+      // Continue the code flow if failed to handle the error
       logger.error(`handleError threw an error ${e}`);
     }
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "scripts": {
     "test": "jest",
-    "test:dev": "jest --watch --runInBand",
+    "test:dev": "node --inspect=9229 node_modules/.bin/jest --watch --runInBand",
     "test:nestjs": "jest --config='./various-receipes/nestjs/ts-jest.config.js'",
     "test:dev:verbose": "jest --watch --verbose",
     "lint": "eslint .",


### PR DESCRIPTION
If `errorHandler.handleError` throw an exception (i.e mailer returns 500) it skips `res.status(error?.status || 500).end();`  and never returns a response to the client which hangs.

Just not sure if empty catch is the best approach 