### PR TITLE
Fixed typo in example-application/start.js

### DIFF
--- a/example-application/start.js
+++ b/example-application/start.js
@@ -11,5 +11,5 @@ start()
     console.log('The app has started successfully');
   })
   .catch((error) => {
-    console.log('App occured during startup', error);
+    console.log('Error occured during startup', error);
   });


### PR DESCRIPTION
At the last of the file, it logs on the console: "App occured during startup" but it should be "Error occured during startup".